### PR TITLE
Added title support for the menu

### DIFF
--- a/Adafruit_Arcada.cpp
+++ b/Adafruit_Arcada.cpp
@@ -422,10 +422,6 @@ uint32_t Adafruit_Arcada::readButtons(void) {
 	 (p.y > height()/4) && (p.y < (height()*3.0/4.0)) ) {
        buttons |= ARCADA_BUTTONMASK_RIGHT;
     }
-    // left!
-    if ( (p.x < width()/4) && (p.y > height()/4) && (p.y < (height()*3.0/4.0)) ) {
-       buttons |= ARCADA_BUTTONMASK_LEFT;
-    }
     // B
     if ( (p.x > width()/4) && (p.x < width()/2) // 2nd quarter
 	 && (p.y > height()/4) && (p.y < (height()*3.0/4.0)) ) {

--- a/Adafruit_Arcada.h
+++ b/Adafruit_Arcada.h
@@ -422,7 +422,7 @@ class Adafruit_Arcada : public ARCADA_TFT_TYPE {
   void errorBox(const char *string, uint32_t continueButtonMask = ARCADA_BUTTONMASK_A);
   void haltBox(const char *string);
   uint8_t menu(const char **menu_strings, uint8_t menu_num, 
-	       uint16_t boxColor, uint16_t textColor, bool cancellable = false, const char *menu_subtitle = "");
+	       uint16_t boxColor, uint16_t textColor, bool cancellable = false, const char *menu_title = "", const char *menu_subtitle = "");
 
   // Configuration JSON files
   bool loadConfigurationFile(const char *filename = ARCADA_DEFAULT_CONFIGURATION_FILENAME);

--- a/Adafruit_Arcada.h
+++ b/Adafruit_Arcada.h
@@ -422,10 +422,7 @@ class Adafruit_Arcada : public ARCADA_TFT_TYPE {
   void errorBox(const char *string, uint32_t continueButtonMask = ARCADA_BUTTONMASK_A);
   void haltBox(const char *string);
   uint8_t menu(const char **menu_strings, uint8_t menu_num, 
-	       uint16_t boxColor, uint16_t textColor, bool cancellable = false);
-  
-  uint8_t menu(const char *menu_title, const char **menu_strings, uint8_t menu_num, 
-	       uint16_t boxColor, uint16_t textColor, const char *menu_subtitle = "", bool cancellable = false);
+	       uint16_t boxColor, uint16_t textColor, bool cancellable = false, const char *menu_subtitle = "");
 
   // Configuration JSON files
   bool loadConfigurationFile(const char *filename = ARCADA_DEFAULT_CONFIGURATION_FILENAME);

--- a/Adafruit_Arcada.h
+++ b/Adafruit_Arcada.h
@@ -423,6 +423,9 @@ class Adafruit_Arcada : public ARCADA_TFT_TYPE {
   void haltBox(const char *string);
   uint8_t menu(const char **menu_strings, uint8_t menu_num, 
 	       uint16_t boxColor, uint16_t textColor, bool cancellable = false);
+  
+  uint8_t menu(const char *menu_title, const char **menu_strings, uint8_t menu_num, 
+	       uint16_t boxColor, uint16_t textColor, const char *menu_subtitle = "", bool cancellable = false);
 
   // Configuration JSON files
   bool loadConfigurationFile(const char *filename = ARCADA_DEFAULT_CONFIGURATION_FILENAME);

--- a/Adafruit_Arcada.h
+++ b/Adafruit_Arcada.h
@@ -425,7 +425,7 @@ class Adafruit_Arcada : public ARCADA_TFT_TYPE {
 	       uint16_t boxColor, uint16_t textColor, bool cancellable = false);
   
   uint8_t menu(const char *menu_title, const char **menu_strings, uint8_t menu_num, 
-	       uint16_t boxColor, uint16_t textColor, const char *menu_subtitle, bool cancellable = false);
+	       uint16_t boxColor, uint16_t textColor, const char *menu_subtitle = "", bool cancellable = false);
 
   // Configuration JSON files
   bool loadConfigurationFile(const char *filename = ARCADA_DEFAULT_CONFIGURATION_FILENAME);

--- a/Adafruit_Arcada.h
+++ b/Adafruit_Arcada.h
@@ -425,7 +425,7 @@ class Adafruit_Arcada : public ARCADA_TFT_TYPE {
 	       uint16_t boxColor, uint16_t textColor, bool cancellable = false);
   
   uint8_t menu(const char *menu_title, const char **menu_strings, uint8_t menu_num, 
-	       uint16_t boxColor, uint16_t textColor, const char *menu_subtitle = "", bool cancellable = false);
+	       uint16_t boxColor, uint16_t textColor, const char *menu_subtitle, bool cancellable = false);
 
   // Configuration JSON files
   bool loadConfigurationFile(const char *filename = ARCADA_DEFAULT_CONFIGURATION_FILENAME);

--- a/Adafruit_Arcada_Alerts.cpp
+++ b/Adafruit_Arcada_Alerts.cpp
@@ -197,13 +197,22 @@ void Adafruit_Arcada::alertBox(const char *string, uint16_t boxColor, uint16_t t
     @param  boxColor 16-bit color to use as menu-background
     @param  textColor 16-bit color to use as outline and text 
     @param  cancellable setting this to true will enable the user to exit the menu by pressing "B"
+    @param  menu_title [optional] if a menu title is given to this function, the "selection hint" won't be drawn
+    @param  menu_subtitle [optional] printed below the title if a string is provided
     @returns uint8_t, The selected menu item, returns 255 if the menu is canceled
 */
 /**************************************************************************/
 uint8_t Adafruit_Arcada::menu(const char **menu_strings, uint8_t menu_num, 
-			      uint16_t boxColor, uint16_t textColor, bool cancellable) {
+			      uint16_t boxColor, uint16_t textColor, bool cancellable, 
+			      const char *menu_title, const char *menu_subtitle) {
+  bool HasTitle = false;
+  if(strlen(menu_title) > 0)HasTitle = true;
+  
+  bool HasSubtitle = false;
+  if(strlen(menu_subtitle) > 0)HasSubtitle = true;
+	
   _initAlertFonts();
-
+	
   uint16_t max_len = 0;
   for (int i=0; i<menu_num; i++) {
     //Serial.printf("#%d '%s' -> %d\n", i, menu_strings[i], strlen(menu_strings[i]));
@@ -211,7 +220,12 @@ uint8_t Adafruit_Arcada::menu(const char **menu_strings, uint8_t menu_num,
   }
 
   uint16_t boxWidth = (max_len + 4) * charWidth;
-  uint16_t boxHeight = (menu_num + 2) * charHeight;
+  uint16_t boxHeight = 0;
+  if(!HasTitle)boxHeight= (menu_num + 2) * charHeight;
+  else{
+	  boxHeight = ((menu_num + 3) * charHeight); //1 line for the title
+	  if(HasSubtitle){boxHeight += charHeight;} //add 1 extra line for the subtitle
+  }
   uint16_t boxX = (width() - boxWidth) / 2;
   uint16_t boxY = (height() - boxHeight) / 2;
 
@@ -219,26 +233,65 @@ uint8_t Adafruit_Arcada::menu(const char **menu_strings, uint8_t menu_num,
   fillRoundRect(boxX, boxY, boxWidth, boxHeight, charWidth, boxColor);
   drawRoundRect(boxX, boxY, boxWidth, boxHeight, charWidth, textColor);
 
-  // Print the selection hint
-  const char *buttonString = "A";
-  uint16_t fontX = boxX + boxWidth - (strlen(buttonString)+1)*charWidth + 2*fontSize;
-  uint16_t fontY = boxY + boxHeight - charHeight;  
-  fillRoundRect(fontX, fontY, 
+  uint16_t fontX = 0;
+  uint16_t fontY = 0;
+	
+  if(HasTitle){
+	  //Print the title
+	  fontX = boxX;
+	  fontY = boxY;
+	  
+	  fillRoundRect(fontX, fontY, boxWidth, charHeight+2, 
+		   charWidth, textColor);
+          drawRoundRect(fontX, fontY, boxWidth, charHeight+2,
+		   charWidth, boxColor);
+          setCursor(fontX + (charWidth/2), fontY+1);
+          setTextColor(boxColor);
+          print(menu_title);
+	  
+	  //draw the sub-title (if available)
+ 	 if(HasSubtitle){
+	     fontX = boxX;
+	     fontY = boxY + charHeight + 2;
+	     fillRoundRect(fontX, fontY, boxWidth, charHeight+2, 
+		   charWidth, textColor);
+  	    drawRoundRect(fontX, fontY, boxWidth, charHeight+2,
+		   charWidth, boxColor);
+	    setCursor(fontX+(charWidth/2), fontY+1);
+  	    setTextColor(boxColor);
+  	    print(menu_subtitle);
+         }
+  }
+  else{
+      // Print the selection hint (if there is no title/subtitle)
+      const char *buttonString = "A";
+      fontX = boxX + boxWidth - (strlen(buttonString)+1)*charWidth + 2*fontSize;
+      fontY = boxY + boxHeight - charHeight;  
+      fillRoundRect(fontX, fontY, 
 		(strlen(buttonString)+2)*charWidth, charHeight*2, 
 		charWidth, textColor);
-  drawRoundRect(fontX, fontY, 
+      drawRoundRect(fontX, fontY, 
 		(strlen(buttonString)+2)*charWidth, charHeight*2,
 		charWidth, boxColor);
-  setCursor(fontX+charWidth, fontY+charHeight/2);
-  setTextColor(boxColor);
-  print(buttonString);
-
-  // draw and select the menu
+      setCursor(fontX+charWidth, fontY+charHeight/2);
+      setTextColor(boxColor);
+      print(buttonString);
+  }
+	
+  // Draw and select the menu
   int8_t selected = 0;
   fontX = boxX + charWidth/2;
   fontY = boxY + charHeight;
-
-  // wait for any buttons to be released
+	
+  // The title and subtitle will shift the selection menu down.
+  if(HasTitle){
+	  fontY += 2;
+	  if(HasSubtitle){
+		  fontY +=2;
+	  }
+  }
+	
+  // Wait for any buttons to be released
   while (readButtons()) delay(10);
 
   while (1) {
@@ -282,122 +335,4 @@ uint8_t Adafruit_Arcada::menu(const char **menu_strings, uint8_t menu_num,
   }
   return selected;
 }
-
-/**************************************************************************/
-/*!
-    @brief  Draws a menu with title and lets a user select one of the menu items 
-    @details 
-    	If this method is called (and not the method without title) the "hint" is not \n
-	displayed at the bottom of the menu (e.g. "A"). \n
-	It is advised to give a "hint" in the sub-menu.
-    @param  menu_title Title to be displayed at the top of the menu
-    @param  menu_strings List of menu-item strings
-    @param  menu_num Number of menu items
-    @param  boxColor 16-bit color to use as menu-background
-    @param  textColor 16-bit color to use as outline and text 
-    @param  menu_subtitle Optional subtitle, displayed below the title 
-    @param  cancellable setting this to true will enable the user to exit the menu by pressing "B"
-    @returns uint8_t, The selected menu item, returns 255 if the menu is canceled
-*/
-/**************************************************************************/
-uint8_t Adafruit_Arcada::menu(const char *menu_title, const char **menu_strings, uint8_t menu_num, 
-	uint16_t boxColor, uint16_t textColor, const char *menu_subtitle, bool cancellable)
-{
-  _initAlertFonts();
-
-  bool HasSubtitle = false;
-  if(strlen(menu_subtitle) > 0)HasSubtitle = true;
-  
-  uint16_t max_len = 0;
-  for (int i=0; i<menu_num; i++) {
-    //Serial.printf("#%d '%s' -> %d\n", i, menu_strings[i], strlen(menu_strings[i]));
-    max_len = max(max_len, strlen(menu_strings[i]));
-  }
-  
-  max_len = max(max_len, strlen(menu_title));
-  if(HasSubtitle)max_len = max(max_len, strlen(menu_subtitle));
-	
-  uint16_t boxWidth = (max_len + 4) * charWidth;
-  uint16_t boxHeight = ((menu_num + 3) * charHeight); //1 line for the title
-  if(HasSubtitle){boxHeight += charHeight;} //add 1 extra line for the subtitle
-  uint16_t boxX = (width() - boxWidth) / 2;
-  uint16_t boxY = (height() - boxHeight) / 2;
-	
-  fillRoundRect(boxX, boxY, boxWidth, boxHeight, charWidth, boxColor);
-  drawRoundRect(boxX, boxY, boxWidth, boxHeight, charWidth, textColor);
-
-  // Print the Title
-  uint16_t fontX = boxX;
-  uint16_t fontY = boxY;
-  fillRoundRect(fontX, fontY, boxWidth, charHeight+2, 
-		charWidth, textColor);
-  drawRoundRect(fontX, fontY, boxWidth, charHeight+2,
-		charWidth, boxColor);
-  setCursor(fontX + (charWidth/2), fontY+1);
-  setTextColor(boxColor);
-  print(menu_title);
-	
-  //draw the sub-menu (if available)
-  if(HasSubtitle){
-	  fontX = boxX;
-	  fontY = boxY + charHeight + 2;
-	  fillRoundRect(fontX, fontY, boxWidth, charHeight+2, 
-		charWidth, textColor);
-  	drawRoundRect(fontX, fontY, boxWidth, charHeight+2,
-		charWidth, boxColor);
-	setCursor(fontX+(charWidth/2), fontY+1);
-  	setTextColor(boxColor);
-  	print(menu_subtitle);
-  }
-
-  // draw and select the menu
-  int8_t selected = 0;
-  fontX = boxX + charWidth/2;
-  fontY = boxY + charHeight + 2;
-  if(HasSubtitle) fontY += charHeight + 2;
-	
-  // wait for any buttons to be released
-  while (readButtons()) delay(10);
-
-  while (1) {
-    for (int i=0; i<menu_num; i++) {
-      if (i == selected) {
-	setTextColor(boxColor, textColor);
-      } else {
-	setTextColor(textColor, boxColor);
-      }
-      setCursor(fontX, fontY+charHeight*i);
-      print(" ");
-      print(menu_strings[i]);
-      for (int j=strlen(menu_strings[i]); j<max_len+2; j++) {
-	print(" ");
-      }
-    }
-
-    while (1) {
-      delay(10);
-      readButtons();
-      uint32_t released = justReleasedButtons();
-      if (released & ARCADA_BUTTONMASK_UP) {
-	selected--;
-	if (selected < 0) 
-	  selected = menu_num-1;
-	break;
-      }
-      if (released & ARCADA_BUTTONMASK_DOWN) {
-	selected++;
-	if (selected > menu_num-1) 
-	  selected = 0;
-	break;
-      }
-      if (released & ARCADA_BUTTONMASK_A) {
-	return selected;
-      }
-      if (cancellable && (released & ARCADA_BUTTONMASK_B)) {
-	return 255;
-      }
-    }    
-  }
-  return selected;
-}	
 	

--- a/Adafruit_Arcada_Alerts.cpp
+++ b/Adafruit_Arcada_Alerts.cpp
@@ -399,8 +399,5 @@ uint8_t Adafruit_Arcada::menu(const char *menu_title, const char **menu_strings,
     }    
   }
   return selected;
-}
-
-	
 }	
 	

--- a/Adafruit_Arcada_Alerts.cpp
+++ b/Adafruit_Arcada_Alerts.cpp
@@ -245,7 +245,7 @@ uint8_t Adafruit_Arcada::menu(const char **menu_strings, uint8_t menu_num,
 	
   if(HasTitle){
 	  //Print the title
-	  fontX = boxX;
+	  fontX = boxX + charWidth/2;;
 	  fontY = boxY;
 	  
 	  fillRoundRect(fontX, fontY, boxWidth, charHeight+2, 
@@ -258,7 +258,7 @@ uint8_t Adafruit_Arcada::menu(const char **menu_strings, uint8_t menu_num,
 	  
 	  //draw the sub-title (if available)
  	 if(HasSubtitle){
-	     fontX = boxX;
+	     fontX = boxX + charWidth/2;;
 	     fontY = boxY + charHeight + 2;
 	     fillRoundRect(fontX, fontY, boxWidth, charHeight+2, 
 		   charWidth, textColor);

--- a/Adafruit_Arcada_Alerts.cpp
+++ b/Adafruit_Arcada_Alerts.cpp
@@ -205,15 +205,22 @@ void Adafruit_Arcada::alertBox(const char *string, uint16_t boxColor, uint16_t t
 uint8_t Adafruit_Arcada::menu(const char **menu_strings, uint8_t menu_num, 
 			      uint16_t boxColor, uint16_t textColor, bool cancellable, 
 			      const char *menu_title, const char *menu_subtitle) {
+  uint16_t max_len = 0;
+  
   bool HasTitle = false;
-  if(strlen(menu_title) > 0)HasTitle = true;
+  if(strlen(menu_title) > 0){
+	  HasTitle = true;
+	  max_len = max(max_len, strlen(menu_title));
+  }
   
   bool HasSubtitle = false;
-  if(strlen(menu_subtitle) > 0)HasSubtitle = true;
-	
+  if(strlen(menu_subtitle) > 0){
+	  HasSubtitle = true;
+	  max_len = max(max_len, strlen(menu_subtitle));
+  }
+  
   _initAlertFonts();
 	
-  uint16_t max_len = 0;
   for (int i=0; i<menu_num; i++) {
     //Serial.printf("#%d '%s' -> %d\n", i, menu_strings[i], strlen(menu_strings[i]));
     max_len = max(max_len, strlen(menu_strings[i]));
@@ -285,9 +292,9 @@ uint8_t Adafruit_Arcada::menu(const char **menu_strings, uint8_t menu_num,
 	
   // The title and subtitle will shift the selection menu down.
   if(HasTitle){
-	  fontY += 2;
+	  fontY += charHeight;
 	  if(HasSubtitle){
-		  fontY +=2;
+		  fontY += charHeight;
 	  }
   }
 	
@@ -335,4 +342,3 @@ uint8_t Adafruit_Arcada::menu(const char **menu_strings, uint8_t menu_num,
   }
   return selected;
 }
-	

--- a/Adafruit_Arcada_Alerts.cpp
+++ b/Adafruit_Arcada_Alerts.cpp
@@ -301,7 +301,7 @@ uint8_t Adafruit_Arcada::menu(const char **menu_strings, uint8_t menu_num,
 */
 /**************************************************************************/
 uint8_t Adafruit_Arcada::menu(const char *menu_title, const char **menu_strings, uint8_t menu_num, 
-	uint16_t boxColor, uint16_t textColor, const char *menu_subtitle = "", bool cancellable = false)
+	uint16_t boxColor, uint16_t textColor, const char *menu_subtitle, bool cancellable)
 {
   _initAlertFonts();
 

--- a/Adafruit_Arcada_Alerts.cpp
+++ b/Adafruit_Arcada_Alerts.cpp
@@ -300,7 +300,7 @@ uint8_t Adafruit_Arcada::menu(const char **menu_strings, uint8_t menu_num,
     @returns uint8_t, The selected menu item, returns 255 if the menu is canceled
 */
 /**************************************************************************/
-uint8_t menu(const char *menu_title, const char **menu_strings, uint8_t menu_num, 
+uint8_t Adafruit_Arcada::menu(const char *menu_title, const char **menu_strings, uint8_t menu_num, 
 	uint16_t boxColor, uint16_t textColor, const char *menu_subtitle = "", bool cancellable = false)
 {
   _initAlertFonts();


### PR DESCRIPTION
Added another menu-method with support for a title and sub-title
Using this method instead of the other will remove the "hint" at the bottom of the menu.
I created this method as a first step to simplify the file-selection menu
(which contains code that needs to be in another .cpp file, like Adafruit_Arcada_Alerts.cpp).