### PR TITLE
Fix extra space in alert after \n in message

### DIFF
--- a/Adafruit_Arcada_Alerts.cpp
+++ b/Adafruit_Arcada_Alerts.cpp
@@ -132,7 +132,9 @@ void Adafruit_Arcada_SPITFT::alertBox(const char *string, uint16_t boxColor,
     if (isprint(string[c]) && string[c] != '\n') {
       display->print(string[c]);
     }
-    fontX += charWidth;
+    if (string[c] != '\n') {
+      fontX += charWidth;
+    }
   }
 
   if (continueButtonMask) {


### PR DESCRIPTION
Fix extra space in alert on \n. An extra space is added at the beginning of the line when a \n is parsed.

- Arduino board:  Edge Badge

- Arduino IDE version (found in Arduino -> About Arduino menu):  1.8.10

- List the steps to reproduce the problem below (if possible attach a sketch or
  copy the sketch code in too): 

Test Code:
```
  sprintf(message, "Yes, you selected '%s'.\nWell done!", "Apples'");
  arcada.infoBox(message,2);
```
Will display:

```
Yes, you selected 
'Apples'.
 Well done!"
```
(notice the space before Well done.

A fix is in Adafruit_Arcada_Alerts::alertBox on line 137

```
(old)<      fontX += charWidth;
(new)>      if (string[c] != '\n') fontX += charWidth;
```

