### PR TITLE
Remove implicit conversion from string to char*

### DIFF
--- a/examples/full_board_tests/arcada_clue_sensorplotter/arcada_clue_sensorplotter.ino
+++ b/examples/full_board_tests/arcada_clue_sensorplotter/arcada_clue_sensorplotter.ino
@@ -36,7 +36,7 @@ extern PDMClass PDM;
 
 // millisecond delay between samples
 #define DELAY_PER_SAMPLE 50
-void plotBuffer(GFXcanvas16 *_canvas, char *title, 
+void plotBuffer(GFXcanvas16 *_canvas, const char *title, 
                 CircularBuffer<float, PLOT_W> &buffer1, 
                 CircularBuffer<float, PLOT_W> &buffer2, 
                 CircularBuffer<float, PLOT_W> &buffer3);
@@ -244,7 +244,7 @@ void loop() {
 /**********************************************************************************/
 
 
-void plotBuffer(GFXcanvas16 *_canvas, char *title, 
+void plotBuffer(GFXcanvas16 *_canvas, const char *title, 
                 CircularBuffer<float, PLOT_W> &buffer1, 
                 CircularBuffer<float, PLOT_W> &buffer2, 
                 CircularBuffer<float, PLOT_W> &buffer3) {


### PR DESCRIPTION
Change function input from "char*" to "const char*" to remove implicit conversion from double-quoted string


Original code contained implicit conversion from string (e.g. `"Temperature (C)"`) to char*. This raises warnings in Arduino IDE but compiles successfully.

We can fix the implicit conversion by explicitly declaring the function inputs as `const char*` type.


Warnings from Arduino IDE 1.8.12 console:
```
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino: In function 'void loop()':
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino:116:55: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                data_buffer, data_buffer2, data_buffer3);
                                                       ^
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino:123:55: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                data_buffer, data_buffer2, data_buffer3);
                                                       ^
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino:130:55: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                data_buffer, data_buffer2, data_buffer3);
                                                       ^
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino:143:55: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                data_buffer, data_buffer2, data_buffer3);
                                                       ^
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino:159:55: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                data_buffer, data_buffer2, data_buffer3);
                                                       ^
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino:167:55: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                data_buffer, data_buffer2, data_buffer3);
                                                       ^
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino:186:55: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                data_buffer, data_buffer2, data_buffer3);
                                                       ^
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino:193:55: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                data_buffer, data_buffer2, data_buffer3);
                                                       ^
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino:206:55: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                data_buffer, data_buffer2, data_buffer3);
                                                       ^
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino:219:55: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                data_buffer, data_buffer2, data_buffer3);
                                                       ^
/tmp/arduino_modified_sketch_576912/arcada_clue_sensorplotter.ino:232:55: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
                data_buffer, data_buffer2, data_buffer3);
```

Changes confirmed working on Alpha version of Adafruit Clue. No apparent changes to title display or overall functionality.