### PR TITLE
Update the repeat timestamp for non repeated button presses.

### DIFF
--- a/Adafruit_Arcada_Filesystem.cpp
+++ b/Adafruit_Arcada_Filesystem.cpp
@@ -515,6 +515,7 @@ bool Adafruit_Arcada_SPITFT::chooseFile(const char *path,
 
     // Check for selection or movement
     if (justPressed) {
+      repeatTimestamp = millis();
       if (justPressed & ARCADA_BUTTONMASK_DOWN) {
         selected_line++;
         if (selected_line >= line) {


### PR DESCRIPTION
This improves usability when moving the file selection up or down a single element. Without this it has a tendency to ‘skip’ over the next element very quickly.

I don’t believe this should negatively affect any platform specifically though I have only been able to test this on a Pygamer M4 so this may be worth a quick test to check it on a platform using separate directional buttons rather than the analog stick.