### PR TITLE
SEL+START didn't start the sound (if no Accel)

### DIFF
--- a/examples/full_board_tests/arcada_pybadge_test/arcada_pybadge_test.ino
+++ b/examples/full_board_tests/arcada_pybadge_test/arcada_pybadge_test.ino
@@ -124,7 +124,7 @@ void loop() {
     }
   } else {
     // no accel, check both SEL/START pressed at once
-    if (arcada.readButtons() & ARCADA_BUTTONMASK_START  & ARCADA_BUTTONMASK_SELECT) {
+    if ((arcada.readButtons() & (ARCADA_BUTTONMASK_START | ARCADA_BUTTONMASK_SELECT)) == (ARCADA_BUTTONMASK_START | ARCADA_BUTTONMASK_SELECT)) {
       playsound = true;
     }
   }


### PR DESCRIPTION
In "arcada_pybadge_test" example,  SEL+START didn't start the sound (if no Accel)
Fixed buttons condition to get expected behavior
