### PR TITLE
Update for Hallowing M4 with MSA311

### DIFF
--- a/Boards/Adafruit_Arcada_HalloWingM4.h
+++ b/Boards/Adafruit_Arcada_HalloWingM4.h
@@ -36,8 +36,10 @@ public:
 
   bool variantBegin(void) {
     accel = new Adafruit_MSA301();
-    if (!accel->begin()) {
-      return false; // couldn't find accelerometer
+    if (!accel->begin()) {       // MSA301 @ 0x26
+      if (!accel->begin(0x62)) { // MSA311 @ 0x62
+        return false;            // couldn't find accelerometer
+      }
     }
     accel->setPowerMode(MSA301_NORMALMODE);
     accel->setDataRate(MSA301_DATARATE_1000_HZ);


### PR DESCRIPTION
Updates code and test sketch to work with original MSA301 Hallowing M4's and revs with MSA311.

Only semi-tested on an original Hallowing M4 with a MSA301. Attached a MSA311 via STEMMA connector. For testing, altered code to pass in the wrong I2C address for the MSA301 to force its init to fail:
```cpp
  // MSA301 @ 0x26 on older revs
  if (arcada.accel->begin(0x11)) {
```
The MSA311 was then found and returned data.

![image](https://user-images.githubusercontent.com/8755041/208749764-9502bf65-62df-4ee8-9c03-e1caf70a06e9.png)

