### PR TITLE
replace cardSize() with sectorCount()

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -6,12 +6,11 @@ jobs:
   clang_and_doxy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - name: Run pre-commit
+      uses: pre-commit/action@v3.0.1
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
          repository: adafruit/ci-arduino
          path: ci
@@ -19,8 +18,8 @@ jobs:
     - name: pre-install
       run: bash ci/actions_install.sh
 
-    - name: clang
-      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 
+#    - name: clang
+#      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r .
 
     - name: doxygen
       env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2020 Diego Elio Pettenò
+#
+# SPDX-License-Identifier: Unlicense
+
+repos:
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v15.0.7
+  hooks:
+  - id: clang-format
+    types_or: [c++, c, header]
+    exclude: \.ino$

--- a/Adafruit_Arcada_USBMSD.cpp
+++ b/Adafruit_Arcada_USBMSD.cpp
@@ -65,7 +65,7 @@ bool Adafruit_Arcada_SPITFT::filesysBeginMSD(
     usb_msc.setUnitReady(false);
     usb_msc.begin();
 
-    uint32_t block_count = Arcada_SD_FileSys.card()->cardSize();
+    uint32_t block_count = Arcada_SD_FileSys.card()->sectorCount();
 #ifdef ARCADA_MSD_DEBUG
     Serial.print("MSD for SD Card - Volume size (MB):  ");
     Serial.println((block_count / 2) / 1024);

--- a/Adafruit_Arcada_USBMSD.cpp
+++ b/Adafruit_Arcada_USBMSD.cpp
@@ -1,6 +1,6 @@
 #include <Adafruit_Arcada.h>
 
-//#define ARCADA_MSD_DEBUG
+// #define ARCADA_MSD_DEBUG
 
 static uint32_t last_access_ms;
 

--- a/arcadatype.h
+++ b/arcadatype.h
@@ -8,7 +8,7 @@
 #include <Adafruit_NeoPixel.h>
 #include <Adafruit_SPIFlash.h>
 #include <Adafruit_WavePlayer.h>
-#include <SdFat.h>
+#include <SdFat_Adafruit_Fork.h>
 #include <TouchScreen.h>
 
 #if defined(USE_TINYUSB)

--- a/examples/full_board_tests/pyportal_arcada_test/ESP32BootROM.cpp
+++ b/examples/full_board_tests/pyportal_arcada_test/ESP32BootROM.cpp
@@ -21,7 +21,7 @@
 
 #include "ESP32BootROM.h"
 
-//#define DEBUG 1
+// #define DEBUG 1
 
 ESP32BootROMClass::ESP32BootROMClass(HardwareSerial &serial, int gpio0Pin,
                                      int resetnPin)


### PR DESCRIPTION
cardSize() is removed from upstream, although we enabled backward-compatible (up coming release). It is still better to use sectorCount() instead
also include SdFat_Adafruit_Fork.h instead of SdFat.h